### PR TITLE
Fix #3: Remove vestigial naabu references and confirm parallel reconnaissance

### DIFF
--- a/src/phases/pre-recon.js
+++ b/src/phases/pre-recon.js
@@ -114,7 +114,6 @@ async function runPreReconWave1(webUrl, sourceDir, variables, config, pipelineTe
       nmap: 'Skipped (pipeline testing mode)',
       subfinder: 'Skipped (pipeline testing mode)',
       whatweb: 'Skipped (pipeline testing mode)',
-
       codeAnalysis
     };
   } else {
@@ -138,9 +137,9 @@ async function runPreReconWave1(webUrl, sourceDir, variables, config, pipelineTe
   // Check if authentication config is provided for login instructions injection
   console.log(chalk.gray(`    → Config check: ${config ? 'present' : 'missing'}, Auth: ${config?.authentication ? 'present' : 'missing'}`));
 
-  const [nmap, subfinder, whatweb, naabu, codeAnalysis] = await Promise.all(operations);
+  const [nmap, subfinder, whatweb, codeAnalysis] = await Promise.all(operations);
 
-  return { nmap, subfinder, whatweb, naabu, codeAnalysis };
+  return { nmap, subfinder, whatweb, codeAnalysis };
 }
 
 // Wave 2: Additional scanning
@@ -190,7 +189,7 @@ async function runPreReconWave2(webUrl, sourceDir, toolAvailability, pipelineTes
 
 // Pure function: Stitch together pre-recon outputs and save to file
 async function stitchPreReconOutputs(outputs, sourceDir) {
-  const [nmap, subfinder, whatweb, naabu, codeAnalysis, ...additionalScans] = outputs;
+  const [nmap, subfinder, whatweb, codeAnalysis, ...additionalScans] = outputs;
 
   // Try to read the code analysis deliverable file
   let codeAnalysisContent = 'No analysis available';
@@ -222,10 +221,6 @@ ${scan.output}
   const report = `
 # Pre-Reconnaissance Report
 
-## Port Discovery (naabu)
-Status: ${naabu?.status || 'Skipped'}
-${naabu?.output || naabu || 'No output'}
-
 ## Network Scanning (nmap)
 Status: ${nmap?.status || 'Skipped'}
 ${nmap?.output || nmap || 'No output'}
@@ -237,6 +232,7 @@ ${subfinder?.output || subfinder || 'No output'}
 ## Technology Detection (whatweb)
 Status: ${whatweb?.status || 'Skipped'}
 ${whatweb?.output || whatweb || 'No output'}
+
 ## Code Analysis
 ${codeAnalysisContent}
 ${additionalSection}
@@ -282,7 +278,6 @@ export async function executePreReconPhase(webUrl, sourceDir, variables, config,
     wave1Results.nmap,
     wave1Results.subfinder,
     wave1Results.whatweb,
-    wave1Results.naabu,
     wave1Results.codeAnalysis,
     ...(wave2Results.schemathesis ? [wave2Results.schemathesis] : [])
   ];


### PR DESCRIPTION
## Summary

This PR addresses issue #3 which requested parallel execution of reconnaissance operations. After analysis, I discovered that **the code was already implementing parallel execution correctly** using `Promise.all()` in Wave 1 and Wave 2 operations.

However, I found and fixed a critical bug: the operations array destructuring expected 5 values (`nmap, subfinder, whatweb, naabu, codeAnalysis`) but only 4 operations were actually being executed. The `naabu` tool was referenced throughout but never invoked.

## Changes

- Removed `naabu` from Wave 1 operations array destructuring
- Removed `naabu` from return object in `runPreReconWave1`
- Removed `naabu` from `stitchPreReconOutputs` function parameters  
- Removed `naabu` section from pre-recon report template
- Removed `naabu` from `executePreReconPhase` results array
- Cleaned up extra blank line in pipeline testing mode return

## Parallel Execution Confirmation

The pre-reconnaissance phase already runs all operations in parallel:

**Wave 1** (lines 121-141):
- `nmap` scan
- `subfinder` subdomain discovery
- `whatweb` technology detection  
- Code analysis (Claude AI)

All 4 operations execute concurrently via `Promise.all()`, reducing total execution time.

**Wave 2** (lines 162-175):
- `schemathesis` API testing (if schemas found)

## Test Results

- Syntax validation: ✅ Passed
- Manual code review: ✅ Passed
- No formal test suite exists in the project

## Impact

This fix prevents potential runtime errors from array destructuring mismatch and improves code clarity by removing unused references.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)